### PR TITLE
altered style.css to make all magifications work for the contacts section.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -340,7 +340,7 @@ th, td {
 
 .contact-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
     gap: 20px;
     margin-top: 20px;
 }


### PR DESCRIPTION
just altered a number and it seems to work on all magnification for me on windows. I looked everything from 25% to 500% magnification and there was no word-wrap for the email for any of the contacts. This should be good to go.